### PR TITLE
feat: busca avançada de eventos

### DIFF
--- a/src/eventos/templates/eventos/evento_list.html
+++ b/src/eventos/templates/eventos/evento_list.html
@@ -22,14 +22,14 @@
     <div class="card shadow-sm border-0 mb-4">
         <div class="card-body">
             <form method="get" class="row g-3">
-                <div class="col-md-6">
+                <div class="col-md-4">
                     <div class="input-group">
                         <span class="input-group-text bg-white"><i class="fas fa-search text-primary"></i></span>
                         <input type="text" name="q" class="form-control" placeholder="Buscar por título do evento..." 
                                value="{{ request.GET.q }}">
                     </div>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <select name="categoria" class="form-select">
                         <option value="">Todas as categorias</option>
                         {% for cat in categorias %}
@@ -38,6 +38,22 @@
                             </option>
                         {% endfor %}
                     </select>
+                </div>
+                <div class="col-md-2">
+                    <input type="date" name="data_inicio" class="form-control"
+                           value="{{ request.GET.data_inicio }}" aria-label="Data inicial">
+                </div>
+                <div class="col-md-2">
+                    <input type="date" name="data_fim" class="form-control"
+                           value="{{ request.GET.data_fim }}" aria-label="Data final">
+                </div>
+                <div class="col-md-2">
+                    <input type="number" name="preco_min" class="form-control" min="0" step="0.01"
+                           placeholder="Preço mín." value="{{ request.GET.preco_min }}">
+                </div>
+                <div class="col-md-2">
+                    <input type="number" name="preco_max" class="form-control" min="0" step="0.01"
+                           placeholder="Preço máx." value="{{ request.GET.preco_max }}">
                 </div>
                 <div class="col-md-2">
                     <button type="submit" class="btn btn-primary w-100">

--- a/src/eventos/templates/eventos/evento_list.html
+++ b/src/eventos/templates/eventos/evento_list.html
@@ -23,14 +23,16 @@
         <div class="card-body">
             <form method="get" class="row g-3">
                 <div class="col-md-4">
+                    <label for="filtro-q" class="visually-hidden">Buscar por título</label>
                     <div class="input-group">
                         <span class="input-group-text bg-white"><i class="fas fa-search text-primary"></i></span>
-                        <input type="text" name="q" class="form-control" placeholder="Buscar por título do evento..." 
+                        <input type="text" id="filtro-q" name="q" class="form-control" placeholder="Buscar por título do evento..."
                                value="{{ request.GET.q }}">
                     </div>
                 </div>
                 <div class="col-md-3">
-                    <select name="categoria" class="form-select">
+                    <label for="filtro-categoria" class="visually-hidden">Categoria</label>
+                    <select id="filtro-categoria" name="categoria" class="form-select">
                         <option value="">Todas as categorias</option>
                         {% for cat in categorias %}
                             <option value="{{ cat.id }}" {% if request.GET.categoria == cat.id|stringformat:"s" %}selected{% endif %}>
@@ -40,19 +42,23 @@
                     </select>
                 </div>
                 <div class="col-md-2">
-                    <input type="date" name="data_inicio" class="form-control"
-                           value="{{ request.GET.data_inicio }}" aria-label="Data inicial">
+                    <label for="filtro-data-inicio" class="visually-hidden">Data inicial</label>
+                    <input type="date" id="filtro-data-inicio" name="data_inicio" class="form-control"
+                           value="{{ request.GET.data_inicio }}">
                 </div>
                 <div class="col-md-2">
-                    <input type="date" name="data_fim" class="form-control"
-                           value="{{ request.GET.data_fim }}" aria-label="Data final">
+                    <label for="filtro-data-fim" class="visually-hidden">Data final</label>
+                    <input type="date" id="filtro-data-fim" name="data_fim" class="form-control"
+                           value="{{ request.GET.data_fim }}">
                 </div>
                 <div class="col-md-2">
-                    <input type="number" name="preco_min" class="form-control" min="0" step="0.01"
+                    <label for="filtro-preco-min" class="visually-hidden">Preço mínimo</label>
+                    <input type="number" id="filtro-preco-min" name="preco_min" class="form-control" min="0" step="0.01"
                            placeholder="Preço mín." value="{{ request.GET.preco_min }}">
                 </div>
                 <div class="col-md-2">
-                    <input type="number" name="preco_max" class="form-control" min="0" step="0.01"
+                    <label for="filtro-preco-max" class="visually-hidden">Preço máximo</label>
+                    <input type="number" id="filtro-preco-max" name="preco_max" class="form-control" min="0" step="0.01"
                            placeholder="Preço máx." value="{{ request.GET.preco_max }}">
                 </div>
                 <div class="col-md-2">

--- a/src/eventos/views.py
+++ b/src/eventos/views.py
@@ -2,8 +2,7 @@ from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.db import transaction
-from django.db.models import Q
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from django.utils import timezone
 from django.utils.dateparse import parse_date
 from .models import Evento, Ingresso, Compra, Categoria, Local
@@ -16,6 +15,24 @@ TEMPLATE_COMPRAR_INGRESSO = 'eventos/comprar_ingresso.html'
 
 def home(request):
     return render(request, 'eventos/home.html')
+
+
+def filtrar_por_data(eventos, campo, valor):
+    data = parse_date(valor) if valor else None
+    if not data:
+        return eventos
+    return eventos.filter(**{campo: data})
+
+
+def filtrar_por_preco(eventos, campo, valor):
+    if not valor:
+        return eventos
+    try:
+        preco = Decimal(valor)
+    except (InvalidOperation, ValueError):
+        return eventos
+    return eventos.filter(**{campo: preco})
+
 
 def lista_eventos(request):
     eventos = Evento.objects.all()
@@ -33,24 +50,11 @@ def lista_eventos(request):
         eventos = eventos.filter(titulo__icontains=q)
     if categoria_id:
         eventos = eventos.filter(categoria_id=categoria_id)
-    if data_inicio:
-        inicio = parse_date(data_inicio)
-        if inicio:
-            eventos = eventos.filter(data_evento__date__gte=inicio)
-    if data_fim:
-        fim = parse_date(data_fim)
-        if fim:
-            eventos = eventos.filter(data_evento__date__lte=fim)
-    if preco_min:
-        try:
-            eventos = eventos.filter(preco_base__gte=Decimal(preco_min))
-        except ArithmeticError:
-            pass
-    if preco_max:
-        try:
-            eventos = eventos.filter(preco_base__lte=Decimal(preco_max))
-        except ArithmeticError:
-            pass
+
+    eventos = filtrar_por_data(eventos, 'data_evento__date__gte', data_inicio)
+    eventos = filtrar_por_data(eventos, 'data_evento__date__lte', data_fim)
+    eventos = filtrar_por_preco(eventos, 'preco_base__gte', preco_min)
+    eventos = filtrar_por_preco(eventos, 'preco_base__lte', preco_max)
 
     return render(request, 'eventos/evento_list.html', {
         'eventos': eventos,

--- a/src/eventos/views.py
+++ b/src/eventos/views.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from django.db.models import Q
 from decimal import Decimal
 from django.utils import timezone
+from django.utils.dateparse import parse_date
 from .models import Evento, Ingresso, Compra, Categoria, Local
 from django.http import HttpResponseForbidden
 from django.views.decorators.http import require_http_methods
@@ -19,18 +20,38 @@ def home(request):
 def lista_eventos(request):
     eventos = Evento.objects.all()
     categorias = Categoria.objects.all()
-    
+
     q = request.GET.get('q')
     categoria_id = request.GET.get('categoria')
     data = request.GET.get('data')
+    data_inicio = request.GET.get('data_inicio') or data
+    data_fim = request.GET.get('data_fim') or data
+    preco_min = request.GET.get('preco_min')
+    preco_max = request.GET.get('preco_max')
 
     if q:
         eventos = eventos.filter(titulo__icontains=q)
     if categoria_id:
         eventos = eventos.filter(categoria_id=categoria_id)
-    if data:
-        eventos = eventos.filter(data_evento__date=data)
-    
+    if data_inicio:
+        inicio = parse_date(data_inicio)
+        if inicio:
+            eventos = eventos.filter(data_evento__date__gte=inicio)
+    if data_fim:
+        fim = parse_date(data_fim)
+        if fim:
+            eventos = eventos.filter(data_evento__date__lte=fim)
+    if preco_min:
+        try:
+            eventos = eventos.filter(preco_base__gte=Decimal(preco_min))
+        except ArithmeticError:
+            pass
+    if preco_max:
+        try:
+            eventos = eventos.filter(preco_base__lte=Decimal(preco_max))
+        except ArithmeticError:
+            pass
+
     return render(request, 'eventos/evento_list.html', {
         'eventos': eventos,
         'categorias': categorias

--- a/tests/test_eventos_views_extra.py
+++ b/tests/test_eventos_views_extra.py
@@ -56,8 +56,43 @@ class EventosViewsExtraTest(TestCase):
         response = self.client.get(reverse('lista_eventos'), {'categoria': self.categoria.id})
         self.assertContains(response, 'Evento Principal')
 
-        response = self.client.get(reverse('lista_eventos'), {'data': self.evento.data_evento.date().isoformat()})
+        data_local = timezone.localtime(self.evento.data_evento).date().isoformat()
+        response = self.client.get(reverse('lista_eventos'), {'data': data_local})
         self.assertContains(response, 'Evento Principal')
+
+    def test_lista_eventos_combina_data_e_faixa_de_preco(self):
+        Evento.objects.create(
+            titulo='Evento Fora do Orçamento',
+            descricao='Descrição',
+            data_evento=timezone.now() + timedelta(days=10),
+            local=self.local,
+            categoria=self.categoria,
+            preco_base=Decimal('200.00'),
+            organizador=self.organizador,
+        )
+        Evento.objects.create(
+            titulo='Evento Fora da Data',
+            descricao='Descrição',
+            data_evento=timezone.now() + timedelta(days=40),
+            local=self.local,
+            categoria=self.categoria,
+            preco_base=Decimal('20.00'),
+            organizador=self.organizador,
+        )
+
+        response = self.client.get(
+            reverse('lista_eventos'),
+            {
+                'data_inicio': (timezone.now() + timedelta(days=9)).date().isoformat(),
+                'data_fim': (timezone.now() + timedelta(days=11)).date().isoformat(),
+                'preco_min': '10.00',
+                'preco_max': '30.00',
+            },
+        )
+
+        self.assertContains(response, 'Evento Principal')
+        self.assertNotContains(response, 'Evento Fora do Orçamento')
+        self.assertNotContains(response, 'Evento Fora da Data')
 
     def test_detalhe_evento_renderiza_ingressos(self):
         response = self.client.get(reverse('detalhe_evento', args=[self.evento.id]))


### PR DESCRIPTION
## Resumo
- adiciona filtros por data inicial, data final, preço mínimo e preço máximo na listagem de eventos
- mantém compatibilidade com o filtro legado por data única
- cobre combinação de filtros por data e faixa de preço

## Testes
- .venv/bin/python manage.py test
- .venv/bin/coverage run manage.py test && .venv/bin/coverage xml && .venv/bin/coverage report -m

Closes #28