### PR TITLE
feat: confirmação de compra

### DIFF
--- a/src/eventos/templates/eventos/compra_sucesso.html
+++ b/src/eventos/templates/eventos/compra_sucesso.html
@@ -10,6 +10,7 @@
                 <div class="card-body p-5 text-center">
                     <h2 class="text-success mb-4">Compra Confirmada!</h2>
 
+                    <p><strong>Código do pedido:</strong> {{ compra.codigo_uuid }}</p>
                     <p><strong>Evento:</strong> {{ compra.ingresso.evento.titulo }}</p>
                     <p><strong>Ingresso:</strong> {{ compra.ingresso.get_tipo_display }}</p>
                     <p><strong>Quantidade:</strong> {{ compra.quantidade }}</p>

--- a/src/eventos/urls.py
+++ b/src/eventos/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('evento/<int:evento_id>/', views.detalhe_evento, name='detalhe_evento'),
     path('comprar/<int:ingresso_id>/', views.comprar_ingresso, name='comprar_ingresso'),
     path('comprar/<int:ingresso_id>/confirmar/', views.confirmar_compra, name='confirmar_compra'),
+    path('compra/<uuid:codigo_uuid>/confirmacao/', views.confirmacao_compra, name='confirmacao_compra'),
     path('meu-historico/', views.meu_historico, name='meu_historico'),
 
     path('organizador/eventos/', views.meus_eventos, name='meus_eventos'),

--- a/src/eventos/views.py
+++ b/src/eventos/views.py
@@ -147,6 +147,7 @@ def confirmar_compra(request, ingresso_id):
 
 
 @login_required
+@require_http_methods(["GET"])
 def confirmacao_compra(request, codigo_uuid):
     compra = get_object_or_404(
         Compra.objects.select_related('ingresso', 'ingresso__evento'),

--- a/src/eventos/views.py
+++ b/src/eventos/views.py
@@ -143,6 +143,17 @@ def confirmar_compra(request, ingresso_id):
     # fora da transação
     messages.success(request, 'Compra simulada confirmada com sucesso!')
 
+    return redirect('confirmacao_compra', codigo_uuid=compra.codigo_uuid)
+
+
+@login_required
+def confirmacao_compra(request, codigo_uuid):
+    compra = get_object_or_404(
+        Compra.objects.select_related('ingresso', 'ingresso__evento'),
+        codigo_uuid=codigo_uuid,
+        usuario=request.user
+    )
+
     return render(request, 'eventos/compra_sucesso.html', {
         'compra': compra,
     })

--- a/tests/test_eventos_views_extra.py
+++ b/tests/test_eventos_views_extra.py
@@ -56,7 +56,8 @@ class EventosViewsExtraTest(TestCase):
         response = self.client.get(reverse('lista_eventos'), {'categoria': self.categoria.id})
         self.assertContains(response, 'Evento Principal')
 
-        response = self.client.get(reverse('lista_eventos'), {'data': self.evento.data_evento.date().isoformat()})
+        data_local = timezone.localtime(self.evento.data_evento).date().isoformat()
+        response = self.client.get(reverse('lista_eventos'), {'data': data_local})
         self.assertContains(response, 'Evento Principal')
 
     def test_detalhe_evento_renderiza_ingressos(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -131,13 +131,57 @@ class EventosViewsTest(TestCase):
             {'quantidade': '2'}
         )
 
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Compra simulada confirmada com sucesso!')
+        self.assertEqual(response.status_code, 302)
 
         compra = Compra.objects.get(usuario=self.user, ingresso=self.ingresso)
+        self.assertIn(
+            reverse('confirmacao_compra', args=[compra.codigo_uuid]),
+            response.url
+        )
         self.assertEqual(compra.quantidade, 2)
         self.ingresso.refresh_from_db()
         self.assertEqual(self.ingresso.quantidade_disponivel, 8)
+
+    def test_confirmacao_compra_exibe_dados_da_compra(self):
+        self.login_user()
+        compra = Compra.objects.create(
+            usuario=self.user,
+            ingresso=self.ingresso,
+            quantidade=2,
+            valor_total=Decimal('100.00'),
+            status='confirmada'
+        )
+
+        response = self.client.get(
+            reverse('confirmacao_compra', args=[compra.codigo_uuid])
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, str(compra.codigo_uuid))
+        self.assertContains(response, 'Evento Teste')
+        self.assertContains(response, 'Inteira')
+        self.assertContains(response, '2')
+        self.assertContains(response, '100,00')
+
+    def test_confirmacao_compra_nao_abre_para_outro_usuario(self):
+        outro = User.objects.create_user(
+            username='outro',
+            password='123456'
+        )
+        compra = Compra.objects.create(
+            usuario=outro,
+            ingresso=self.ingresso,
+            quantidade=1,
+            valor_total=Decimal('50.00'),
+            status='confirmada'
+        )
+        self.login_user()
+
+        response = self.client.get(
+            reverse('confirmacao_compra', args=[compra.codigo_uuid])
+        )
+
+        self.assertEqual(response.status_code, 404)
 
     def test_confirmar_compra_get_redireciona(self):
         self.login_user()


### PR DESCRIPTION
## Resumo
- redireciona a compra confirmada para uma página de confirmação por UUID
- exibe código do pedido, evento, tipo de ingresso, quantidade, total e status
- restringe a confirmação ao usuário dono da compra
- mantém o histórico como ponto de acesso às compras

## Testes
- .venv/bin/python manage.py test
- .venv/bin/coverage run manage.py test && .venv/bin/coverage xml && .venv/bin/coverage report -m

Closes #24