### PR TITLE
feat: lembrete de evento por e-mail

### DIFF
--- a/src/eventos/tasks.py
+++ b/src/eventos/tasks.py
@@ -1,5 +1,6 @@
 from celery import shared_task
 from django.core.mail import send_mail
+from django.utils import timezone
 
 @shared_task
 def send_confirmation_email(email, evento, quantidade, codigo):
@@ -18,3 +19,48 @@ Código da compra: {codigo}
         recipient_list=[email],
         fail_silently=True
     )
+
+
+@shared_task
+def send_event_reminder(compra_id):
+    from .models import Compra
+
+    compra = Compra.objects.select_related(
+        'usuario',
+        'ingresso',
+        'ingresso__evento'
+    ).filter(id=compra_id).first()
+
+    if not compra or compra.status == 'cancelada':
+        return False
+
+    evento = compra.ingresso.evento
+
+    send_mail(
+        subject=f'Lembrete do evento {evento.titulo}',
+        message=f'''
+Olá, {compra.usuario.username}!
+
+Seu evento acontece em 24 horas.
+
+Evento: {evento.titulo}
+Data: {timezone.localtime(evento.data_evento).strftime('%d/%m/%Y %H:%M')}
+Quantidade: {compra.quantidade}
+Código da compra: {compra.codigo_uuid}
+''',
+        from_email=None,
+        recipient_list=[compra.usuario.email],
+        fail_silently=True
+    )
+
+    return True
+
+
+def schedule_event_reminder(compra):
+    evento = compra.ingresso.evento
+    eta = evento.data_evento - timezone.timedelta(hours=24)
+
+    if eta <= timezone.now():
+        return None
+
+    return send_event_reminder.apply_async(args=[compra.id], eta=eta)

--- a/src/eventos/views.py
+++ b/src/eventos/views.py
@@ -9,6 +9,7 @@ from .models import Evento, Ingresso, Compra, Categoria, Local
 from django.http import HttpResponseForbidden
 from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
+from .tasks import schedule_event_reminder
 
 # Template constants
 TEMPLATE_COMPRAR_INGRESSO = 'eventos/comprar_ingresso.html'
@@ -141,6 +142,7 @@ def confirmar_compra(request, ingresso_id):
         ingresso.save(update_fields=['quantidade_disponivel'])
 
     # fora da transação
+    schedule_event_reminder(compra)
     messages.success(request, 'Compra simulada confirmada com sucesso!')
 
     return render(request, 'eventos/compra_sucesso.html', {

--- a/tests/test_event_reminders.py
+++ b/tests/test_event_reminders.py
@@ -1,0 +1,84 @@
+from datetime import timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+
+from eventos.models import Categoria, Compra, Evento, Ingresso, Local
+from eventos.tasks import schedule_event_reminder, send_event_reminder
+
+
+class EventReminderTaskTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='participante',
+            email='participante@example.com',
+            password='StrongPass123!',
+        )
+        self.categoria = Categoria.objects.create(nome='Tecnologia')
+        self.local = Local.objects.create(nome='Auditório', capacidade=100)
+        self.evento = Evento.objects.create(
+            titulo='Semana Acadêmica',
+            descricao='Evento universitário',
+            data_evento=timezone.now() + timedelta(days=3),
+            local=self.local,
+            categoria=self.categoria,
+            preco_base=Decimal('30.00'),
+            organizador=self.user,
+        )
+        self.ingresso = Ingresso.objects.create(
+            evento=self.evento,
+            tipo='inteira',
+            preco=Decimal('30.00'),
+            quantidade_disponivel=10,
+        )
+        self.compra = Compra.objects.create(
+            usuario=self.user,
+            ingresso=self.ingresso,
+            quantidade=1,
+            valor_total=Decimal('30.00'),
+            status='confirmada',
+        )
+
+    @patch('eventos.tasks.send_event_reminder.apply_async')
+    def test_schedule_event_reminder_agenda_para_24h_antes(self, apply_async_mock):
+        schedule_event_reminder(self.compra)
+
+        expected_eta = self.evento.data_evento - timedelta(hours=24)
+        apply_async_mock.assert_called_once_with(
+            args=[self.compra.id],
+            eta=expected_eta
+        )
+
+    @patch('eventos.tasks.send_event_reminder.apply_async')
+    def test_schedule_event_reminder_nao_agenda_evento_muito_proximo(self, apply_async_mock):
+        self.evento.data_evento = timezone.now() + timedelta(hours=2)
+        self.evento.save(update_fields=['data_evento'])
+
+        result = schedule_event_reminder(self.compra)
+
+        self.assertIsNone(result)
+        apply_async_mock.assert_not_called()
+
+    @patch('eventos.tasks.send_mail')
+    def test_send_event_reminder_envia_email_para_compra_confirmada(self, send_mail_mock):
+        result = send_event_reminder(self.compra.id)
+
+        self.assertTrue(result)
+        send_mail_mock.assert_called_once()
+        self.assertEqual(
+            send_mail_mock.call_args.kwargs['recipient_list'],
+            ['participante@example.com']
+        )
+
+    @patch('eventos.tasks.send_mail')
+    def test_send_event_reminder_nao_envia_compra_cancelada(self, send_mail_mock):
+        self.compra.status = 'cancelada'
+        self.compra.save(update_fields=['status'])
+
+        result = send_event_reminder(self.compra.id)
+
+        self.assertFalse(result)
+        send_mail_mock.assert_not_called()

--- a/tests/test_eventos_views_extra.py
+++ b/tests/test_eventos_views_extra.py
@@ -56,7 +56,8 @@ class EventosViewsExtraTest(TestCase):
         response = self.client.get(reverse('lista_eventos'), {'categoria': self.categoria.id})
         self.assertContains(response, 'Evento Principal')
 
-        response = self.client.get(reverse('lista_eventos'), {'data': self.evento.data_evento.date().isoformat()})
+        data_local = timezone.localtime(self.evento.data_evento).date().isoformat()
+        response = self.client.get(reverse('lista_eventos'), {'data': data_local})
         self.assertContains(response, 'Evento Principal')
 
     def test_detalhe_evento_renderiza_ingressos(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from datetime import timedelta
 from eventos.models import Evento, Categoria, Local, Ingresso, Compra
 from django.utils import timezone
+from unittest.mock import patch
 
 
 class EventosViewsTest(TestCase):
@@ -123,7 +124,8 @@ class EventosViewsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Quantidade indisponível para este ingresso.')
 
-    def test_confirmar_compra_cria_compra_e_reduz_estoque(self):
+    @patch('eventos.views.schedule_event_reminder')
+    def test_confirmar_compra_cria_compra_e_reduz_estoque(self, schedule_mock):
         self.login_user()
 
         response = self.client.post(
@@ -135,6 +137,7 @@ class EventosViewsTest(TestCase):
         self.assertContains(response, 'Compra simulada confirmada com sucesso!')
 
         compra = Compra.objects.get(usuario=self.user, ingresso=self.ingresso)
+        schedule_mock.assert_called_once_with(compra)
         self.assertEqual(compra.quantidade, 2)
         self.ingresso.refresh_from_db()
         self.assertEqual(self.ingresso.quantidade_disponivel, 8)


### PR DESCRIPTION
## Resumo
- adiciona task Celery para enviar lembrete 24h antes do evento
- agenda a task automaticamente após a compra confirmada
- evita envio quando a compra estiver cancelada no momento da execução
- cobre agendamento por ETA, evento muito próximo e compra cancelada com mocks

## Testes
- .venv/bin/python manage.py test
- .venv/bin/coverage run manage.py test && .venv/bin/coverage xml && .venv/bin/coverage report -m

Closes #34