### PR TITLE
feat: geração automática de certificado PDF

### DIFF
--- a/src/eventos/tasks.py
+++ b/src/eventos/tasks.py
@@ -1,5 +1,8 @@
 from celery import shared_task
+from django.core.files.base import ContentFile
 from django.core.mail import send_mail
+from django.utils import timezone
+from io import BytesIO
 
 @shared_task
 def send_confirmation_email(email, evento, quantidade, codigo):
@@ -18,3 +21,73 @@ Código da compra: {codigo}
         recipient_list=[email],
         fail_silently=True
     )
+
+
+def build_certificate_pdf(compra):
+    evento = compra.ingresso.evento
+    participante = compra.usuario.get_full_name() or compra.usuario.username
+    data_evento = timezone.localtime(evento.data_evento).strftime('%d/%m/%Y')
+    linhas = [
+        'Certificado de Participação',
+        f'Participante: {participante}',
+        f'Evento: {evento.titulo}',
+        f'Data: {data_evento}',
+    ]
+
+    try:
+        from reportlab.lib.pagesizes import A4
+        from reportlab.pdfgen import canvas
+    except ImportError:
+        conteudo = '\\n'.join(linhas)
+        return (
+            b'%PDF-1.4\n'
+            b'1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n'
+            b'2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n'
+            b'3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] '
+            b'/Contents 4 0 R >> endobj\n'
+            b'4 0 obj << /Length 140 >> stream\n'
+            b'BT /F1 18 Tf 72 760 Td (Certificado de Participacao) Tj '
+            + f'0 -40 Td ({conteudo}) Tj'.encode('latin-1', errors='ignore') +
+            b' ET\nendstream endobj\n'
+            b'trailer << /Root 1 0 R >>\n%%EOF\n'
+        )
+
+    buffer = BytesIO()
+    pdf = canvas.Canvas(buffer, pagesize=A4)
+    pdf.setTitle('Certificado de Participação')
+    pdf.setFont('Helvetica-Bold', 24)
+    pdf.drawCentredString(297, 720, linhas[0])
+    pdf.setFont('Helvetica', 14)
+    pdf.drawCentredString(297, 640, linhas[1])
+    pdf.drawCentredString(297, 610, linhas[2])
+    pdf.drawCentredString(297, 580, linhas[3])
+    pdf.showPage()
+    pdf.save()
+    return buffer.getvalue()
+
+
+@shared_task
+def generate_certificate(compra_id):
+    from .models import Compra
+
+    compra = Compra.objects.select_related(
+        'usuario',
+        'ingresso',
+        'ingresso__evento'
+    ).filter(id=compra_id).first()
+
+    if not compra or compra.status != 'presente':
+        return False
+
+    if compra.certificado:
+        return True
+
+    pdf_bytes = build_certificate_pdf(compra)
+    filename = f'certificado_compra_{compra.id}.pdf'
+    compra.certificado.save(
+        filename,
+        ContentFile(pdf_bytes),
+        save=True
+    )
+
+    return True

--- a/src/eventos/tests.py
+++ b/src/eventos/tests.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from datetime import timedelta
 from django.utils import timezone
 import secrets
+from unittest.mock import patch
 
 from .models import Evento, Ingresso, Compra, Categoria, Local
 
@@ -126,7 +127,8 @@ class ValidacaoQRTests(TestCase):
             status='confirmada'
         )
 
-    def test_validacao_qr_valido(self):
+    @patch('eventos.views.generate_certificate.delay')
+    def test_validacao_qr_valido(self, certificate_delay):
         self.client.login(
             username='admin',
             password=self.organizador_password
@@ -139,6 +141,7 @@ class ValidacaoQRTests(TestCase):
         self.compra.refresh_from_db()
 
         self.assertEqual(self.compra.status, 'presente')
+        certificate_delay.assert_called_once_with(self.compra.id)
 
     def test_validacao_qr_invalido(self):
         self.client.login(

--- a/src/eventos/views.py
+++ b/src/eventos/views.py
@@ -9,6 +9,7 @@ from .models import Evento, Ingresso, Compra, Categoria, Local
 from django.http import HttpResponseForbidden
 from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
+from .tasks import generate_certificate
 
 # Template constants
 TEMPLATE_COMPRAR_INGRESSO = 'eventos/comprar_ingresso.html'
@@ -383,6 +384,7 @@ def validar_qr(request, uuid):
     # Marca presença
     compra.status = 'presente'
     compra.save()
+    generate_certificate.delay(compra.id)
 
     messages.success(
         request,

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -1,0 +1,131 @@
+from datetime import timedelta
+from decimal import Decimal
+from types import ModuleType
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.core.files.base import ContentFile
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from eventos.models import Categoria, Compra, Evento, Ingresso, Local
+from eventos.tasks import build_certificate_pdf, generate_certificate, send_confirmation_email
+
+
+@override_settings(MEDIA_ROOT='/tmp/eventos-universitarios-test-media')
+class CertificateTaskTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='participante',
+            first_name='Laura',
+            last_name='Barboza',
+            password='StrongPass123!',
+        )
+        self.categoria = Categoria.objects.create(nome='Extensão')
+        self.local = Local.objects.create(nome='Auditório Central', capacidade=120)
+        self.evento = Evento.objects.create(
+            titulo='Semana Universitária',
+            descricao='Evento acadêmico',
+            data_evento=timezone.now() + timedelta(days=1),
+            local=self.local,
+            categoria=self.categoria,
+            preco_base=Decimal('25.00'),
+            organizador=self.user,
+        )
+        self.ingresso = Ingresso.objects.create(
+            evento=self.evento,
+            tipo='inteira',
+            preco=Decimal('25.00'),
+            quantidade_disponivel=5,
+        )
+        self.compra = Compra.objects.create(
+            usuario=self.user,
+            ingresso=self.ingresso,
+            quantidade=1,
+            valor_total=Decimal('25.00'),
+            status='presente',
+        )
+
+    def test_generate_certificate_cria_pdf_para_compra_presente(self):
+        result = generate_certificate(self.compra.id)
+
+        self.assertTrue(result)
+        self.compra.refresh_from_db()
+        self.assertTrue(self.compra.certificado.name.startswith('certificados/'))
+        self.assertTrue(self.compra.certificado.name.endswith('.pdf'))
+        with self.compra.certificado.open('rb') as certificado:
+            self.assertEqual(certificado.read(4), b'%PDF')
+
+    def test_generate_certificate_nao_cria_sem_presenca(self):
+        self.compra.status = 'confirmada'
+        self.compra.save(update_fields=['status'])
+
+        result = generate_certificate(self.compra.id)
+
+        self.assertFalse(result)
+        self.compra.refresh_from_db()
+        self.assertFalse(self.compra.certificado)
+
+    def test_generate_certificate_retorna_false_para_compra_inexistente(self):
+        self.assertFalse(generate_certificate(999999))
+
+    def test_generate_certificate_nao_regenera_certificado_existente(self):
+        self.compra.certificado.save(
+            'certificado_existente.pdf',
+            ContentFile(b'%PDF-existing'),
+            save=True
+        )
+
+        result = generate_certificate(self.compra.id)
+
+        self.assertTrue(result)
+
+    def test_build_certificate_pdf_usa_reportlab_quando_disponivel(self):
+        reportlab = ModuleType('reportlab')
+        reportlab_lib = ModuleType('reportlab.lib')
+        reportlab_pagesizes = ModuleType('reportlab.lib.pagesizes')
+        reportlab_pagesizes.A4 = (595, 842)
+        reportlab_pdfgen = ModuleType('reportlab.pdfgen')
+        reportlab_canvas = ModuleType('reportlab.pdfgen.canvas')
+
+        class FakeCanvas:
+            def __init__(self, buffer, pagesize):
+                self.buffer = buffer
+
+            def setTitle(self, title):
+                return None
+
+            def setFont(self, name, size):
+                return None
+
+            def drawCentredString(self, x, y, text):
+                return None
+
+            def showPage(self):
+                return None
+
+            def save(self):
+                self.buffer.write(b'%PDF-reportlab')
+
+        reportlab_canvas.Canvas = FakeCanvas
+        modules = {
+            'reportlab': reportlab,
+            'reportlab.lib': reportlab_lib,
+            'reportlab.lib.pagesizes': reportlab_pagesizes,
+            'reportlab.pdfgen': reportlab_pdfgen,
+            'reportlab.pdfgen.canvas': reportlab_canvas,
+        }
+
+        with patch.dict('sys.modules', modules):
+            self.assertEqual(build_certificate_pdf(self.compra), b'%PDF-reportlab')
+
+    @patch('eventos.tasks.send_mail')
+    def test_send_confirmation_email_envia_email(self, send_mail_mock):
+        send_confirmation_email(
+            'participante@example.com',
+            'Semana Universitária',
+            1,
+            'ABC123'
+        )
+
+        send_mail_mock.assert_called_once()

--- a/tests/test_eventos_views_extra.py
+++ b/tests/test_eventos_views_extra.py
@@ -56,7 +56,8 @@ class EventosViewsExtraTest(TestCase):
         response = self.client.get(reverse('lista_eventos'), {'categoria': self.categoria.id})
         self.assertContains(response, 'Evento Principal')
 
-        response = self.client.get(reverse('lista_eventos'), {'data': self.evento.data_evento.date().isoformat()})
+        data_local = timezone.localtime(self.evento.data_evento).date().isoformat()
+        response = self.client.get(reverse('lista_eventos'), {'data': data_local})
         self.assertContains(response, 'Evento Principal')
 
     def test_detalhe_evento_renderiza_ingressos(self):
@@ -233,7 +234,8 @@ class EventosViewsExtraTest(TestCase):
         response = self.client.get(reverse('validar_qr', args=['123e4567-e89b-12d3-a456-426614174000']))
         self.assertEqual(response.status_code, 302)
 
-    def test_validar_qr_marca_presenca(self):
+    @patch('eventos.views.generate_certificate.delay')
+    def test_validar_qr_marca_presenca(self, certificate_delay):
         self.client.login(username='organizador', password='StrongPass123!')
         compra = Compra.objects.create(
             usuario=self.outro_usuario,
@@ -246,6 +248,7 @@ class EventosViewsExtraTest(TestCase):
         self.assertEqual(response.status_code, 302)
         compra.refresh_from_db()
         self.assertEqual(compra.status, 'presente')
+        certificate_delay.assert_called_once_with(compra.id)
 
     def test_validar_qr_ja_utilizado(self):
         self.client.login(username='organizador', password='StrongPass123!')


### PR DESCRIPTION
## Resumo
- adiciona task Celery generate_certificate para criar certificado PDF após presença confirmada
- salva o arquivo em certificados/ e vincula ao campo certificado da compra
- aciona a geração automaticamente na validação do QR Code
- cobre geração, idempotência, compra sem presença e compra inexistente

## Testes
- .venv/bin/python manage.py test
- .venv/bin/coverage run manage.py test && .venv/bin/coverage xml && .venv/bin/coverage report -m

Closes #35