### PR TITLE
feat: download protegido de certificado

### DIFF
--- a/src/eventos/templates/eventos/meu_historico.html
+++ b/src/eventos/templates/eventos/meu_historico.html
@@ -142,7 +142,7 @@ Meu Histórico - Eventos Universitários
             {% endif %}
 
             {% if compra.status == 'presente' and compra.certificado %}
-              <a href="{{ compra.certificado.url }}"
+              <a href="{% url 'download_certificado' compra.id %}"
                  class="btn btn-sm btn-success">
                 <i class="fas fa-download me-1"></i>
                 Baixar Certificado

--- a/src/eventos/urls.py
+++ b/src/eventos/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('comprar/<int:ingresso_id>/', views.comprar_ingresso, name='comprar_ingresso'),
     path('comprar/<int:ingresso_id>/confirmar/', views.confirmar_compra, name='confirmar_compra'),
     path('meu-historico/', views.meu_historico, name='meu_historico'),
+    path('certificados/<int:compra_id>/download/', views.download_certificado, name='download_certificado'),
 
     path('organizador/eventos/', views.meus_eventos, name='meus_eventos'),
     path('organizador/evento/criar/', views.criar_evento, name='criar_evento'),

--- a/src/eventos/views.py
+++ b/src/eventos/views.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from decimal import Decimal
 from django.utils import timezone
 from .models import Evento, Ingresso, Compra, Categoria, Local
-from django.http import HttpResponseForbidden
+from django.http import FileResponse, Http404, HttpResponseForbidden
 from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
 
@@ -157,6 +157,28 @@ def meu_historico(request):
     return render(request, 'eventos/meu_historico.html', {
         'compras': compras
     })
+
+
+@login_required
+@require_http_methods(["GET"])
+def download_certificado(request, compra_id):
+    compra = get_object_or_404(
+        Compra.objects.select_related('ingresso', 'ingresso__evento'),
+        id=compra_id,
+        usuario=request.user,
+        status='presente'
+    )
+
+    if not compra.certificado:
+        raise Http404('Certificado não encontrado.')
+
+    filename = f'certificado-{compra.codigo_uuid}.pdf'
+    return FileResponse(
+        compra.certificado.open('rb'),
+        as_attachment=True,
+        filename=filename,
+        content_type='application/pdf'
+    )
 
 # ==================== VIEWS DO ORGANIZADOR ====================
 

--- a/tests/test_certificate_download.py
+++ b/tests/test_certificate_download.py
@@ -1,0 +1,95 @@
+from datetime import timedelta
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.core.files.base import ContentFile
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from eventos.models import Categoria, Compra, Evento, Ingresso, Local
+
+
+@override_settings(MEDIA_ROOT='/tmp/eventos-universitarios-test-media')
+class CertificateDownloadTest(TestCase):
+    def setUp(self):
+        self.password = 'StrongPass123!'
+        self.user = User.objects.create_user(
+            username='participante',
+            password=self.password,
+        )
+        self.outro_usuario = User.objects.create_user(
+            username='outro',
+            password=self.password,
+        )
+        self.categoria = Categoria.objects.create(nome='Tecnologia')
+        self.local = Local.objects.create(nome='Auditório', capacidade=100)
+        self.evento = Evento.objects.create(
+            titulo='Evento com Certificado',
+            descricao='Evento',
+            data_evento=timezone.now() + timedelta(days=1),
+            local=self.local,
+            categoria=self.categoria,
+            preco_base=Decimal('20.00'),
+            organizador=self.user,
+        )
+        self.ingresso = Ingresso.objects.create(
+            evento=self.evento,
+            tipo='inteira',
+            preco=Decimal('20.00'),
+            quantidade_disponivel=5,
+        )
+        self.compra = Compra.objects.create(
+            usuario=self.user,
+            ingresso=self.ingresso,
+            quantidade=1,
+            valor_total=Decimal('20.00'),
+            status='presente',
+        )
+        self.compra.certificado.save(
+            'certificado.pdf',
+            ContentFile(b'%PDF-1.4 certificado'),
+            save=True
+        )
+
+    def test_historico_exibe_link_de_download_do_certificado(self):
+        self.client.login(username='participante', password=self.password)
+
+        response = self.client.get(reverse('meu_historico'))
+
+        self.assertContains(response, reverse('download_certificado', args=[self.compra.id]))
+        self.assertContains(response, 'Baixar Certificado')
+
+    def test_download_certificado_autorizado(self):
+        self.client.login(username='participante', password=self.password)
+
+        response = self.client.get(reverse('download_certificado', args=[self.compra.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/pdf')
+        self.assertIn('attachment;', response['Content-Disposition'])
+        self.assertEqual(b''.join(response.streaming_content), b'%PDF-1.4 certificado')
+
+    def test_download_certificado_nao_abre_para_outro_usuario(self):
+        self.client.login(username='outro', password=self.password)
+
+        response = self.client.get(reverse('download_certificado', args=[self.compra.id]))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_download_certificado_exige_presenca_confirmada(self):
+        self.compra.status = 'confirmada'
+        self.compra.save(update_fields=['status'])
+        self.client.login(username='participante', password=self.password)
+
+        response = self.client.get(reverse('download_certificado', args=[self.compra.id]))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_download_certificado_retorna_404_sem_arquivo(self):
+        self.compra.certificado.delete(save=True)
+        self.client.login(username='participante', password=self.password)
+
+        response = self.client.get(reverse('download_certificado', args=[self.compra.id]))
+
+        self.assertEqual(response.status_code, 404)

--- a/tests/test_eventos_views_extra.py
+++ b/tests/test_eventos_views_extra.py
@@ -56,7 +56,8 @@ class EventosViewsExtraTest(TestCase):
         response = self.client.get(reverse('lista_eventos'), {'categoria': self.categoria.id})
         self.assertContains(response, 'Evento Principal')
 
-        response = self.client.get(reverse('lista_eventos'), {'data': self.evento.data_evento.date().isoformat()})
+        data_local = timezone.localtime(self.evento.data_evento).date().isoformat()
+        response = self.client.get(reverse('lista_eventos'), {'data': data_local})
         self.assertContains(response, 'Evento Principal')
 
     def test_detalhe_evento_renderiza_ingressos(self):


### PR DESCRIPTION
## Resumo
- adiciona rota autenticada para download de certificado em PDF
- valida dono da compra, presença confirmada e arquivo disponível
- troca o link do histórico para usar a rota protegida
- cobre download autorizado e acessos inválidos com 404

## Testes
- .venv/bin/python manage.py test
- .venv/bin/coverage run manage.py test && .venv/bin/coverage xml && .venv/bin/coverage report -m

Closes #36